### PR TITLE
 Rename tests to align with test naming taught in lessons

### DIFF
--- a/tests/test_wave_01.py
+++ b/tests/test_wave_01.py
@@ -3,7 +3,7 @@ import pytest
 from viewing_party.main import *
 
 
-def test_create_successful_movie():
+def test_create_movie_all_params_valid_returns_movie():
     # Arrange
     movie_title = "Title A"
     genre = "Horror"
@@ -18,7 +18,7 @@ def test_create_successful_movie():
     assert new_movie["rating"] is 3.5
 
 
-def test_create_no_title_movie():
+def test_create_movie_no_title_returns_none():
     # Arrange
     movie_title = None
     genre = "Horror"
@@ -31,7 +31,7 @@ def test_create_no_title_movie():
     assert new_movie is None
 
 
-def test_create_no_genre_movie():
+def test_create_movie_no_genre_returns_none():
     # Arrange
     movie_title = "Title A"
     genre = None
@@ -44,7 +44,7 @@ def test_create_no_genre_movie():
     assert new_movie is None
 
 
-def test_create_no_rating_movie():
+def test_create_movie_no_rating_returns_none():
     # Arrange
     movie_title = "Title A"
     genre = "Horror"
@@ -57,7 +57,7 @@ def test_create_no_rating_movie():
     assert new_movie is None
 
 
-def test_adds_movie_to_user_watched():
+def test_add_to_watched_adds_movie_to_user_watched():
     # Arrange
     movie = {
         "title": "Title A",
@@ -78,7 +78,7 @@ def test_adds_movie_to_user_watched():
     assert updated_data["watched"][0]["rating"] is 3.5
 
 
-def test_adds_movie_to_user_watchlist():
+def test_add_to_watchlist_adds_movie_to_user_watchlist():
     # Arrange
     movie = {
         "title": "Title A",
@@ -99,7 +99,7 @@ def test_adds_movie_to_user_watchlist():
     assert updated_data["watchlist"][0]["rating"] is 3.5
 
 
-def test_moves_movie_from_watchlist_to_empty_watched():
+def test_watch_movie_moves_movie_from_watchlist_to_empty_watched():
     # Arrange
     janes_data = {
         "watchlist": [{
@@ -121,7 +121,7 @@ def test_moves_movie_from_watchlist_to_empty_watched():
     assert updated_data["watched"][0]["rating"] is 4.8
 
 
-def test_moves_movie_from_watchlist_to_watched():
+def test_watch_movie_moves_movie_from_watchlist_to_watched():
     # Arrange
     movie_to_watch = {
         "title": "Title A",
@@ -155,7 +155,7 @@ def test_moves_movie_from_watchlist_to_watched():
     assert movie_to_watch in updated_data["watched"]
 
 
-def test_does_nothing_if_movie_not_in_watchlist():
+def test_watch_movie_does_nothing_if_movie_not_in_watchlist():
     # Arrange
     movie_to_watch = {
         "title": "Title A",

--- a/tests/test_wave_02.py
+++ b/tests/test_wave_02.py
@@ -2,7 +2,7 @@ import pytest
 from viewing_party.main import *
 
 
-def test_calculates_watched_average_rating():
+def test_get_watched_avg_rating_calculates_watched_average_rating():
     # Arrange
     janes_data = {
         "watched": [
@@ -31,7 +31,7 @@ def test_calculates_watched_average_rating():
     assert average == pytest.approx(3.56666666664)
 
 
-def test_empty_watched_average_rating_is_zero():
+def test_get_watched_avg_rating_returns_zero_for_empty_list():
     # Arrange
     janes_data = {
         "watched": [
@@ -45,7 +45,7 @@ def test_empty_watched_average_rating_is_zero():
     assert average == pytest.approx(0.0)
 
 
-def test_most_watched_genre():
+def test_get_most_watched_genre_returns_most_frequent_genre_from_list():
     # Arrange
     janes_data = {
         "watched": [
@@ -79,7 +79,7 @@ def test_most_watched_genre():
     assert popular_genre is "Intrigue"
 
 
-def test_genre_is_None_if_empty_watched():
+def test_get_most_watched_genre_returns_None_if_empty_watched():
     # Arrange
     janes_data = {
         "watched": []

--- a/tests/test_wave_03.py
+++ b/tests/test_wave_03.py
@@ -2,7 +2,7 @@ import pytest
 from viewing_party.main import *
 
 
-def test_my_unique_movies():
+def test_get_unique_watched_returns_list_of_movies_in_amandas_data_absent_from_their_friends_data():
     # Arrange
     amandas_data = {
         "watched": [
@@ -58,7 +58,7 @@ def test_my_unique_movies():
     assert {"title": "Title E"} in amandas_unique_movies
 
 
-def test_my_not_unique_movies():
+def test_get_unique_watched_returns_empty_list_when_amandas_movies_are_all_in_her_friends_movies():
     # Arrange
     amandas_data = {
         "watched": [],
@@ -96,13 +96,10 @@ def test_my_not_unique_movies():
     assert len(amandas_unique_movies) is 0
 
 
-def test_friends_unique_movies():
+def test_get_friends_unique_watched_returns_list_of_movies_amanda_has_not_watched_and_friends_have_but_does_not_include_two_of_the_same_movie():
     # Arrange
     amandas_data = {
         "watched": [
-            {
-                "title": "Title A"
-            },
             {
                 "title": "Title B"
             },
@@ -141,12 +138,13 @@ def test_friends_unique_movies():
     friends_unique_movies = get_friends_unique_watched(amandas_data)
 
     # Arrange
-    assert len(friends_unique_movies) is 2
+    assert len(friends_unique_movies) is 3
+    assert {"title": "Title A"} in friends_unique_movies
     assert {"title": "Title D"} in friends_unique_movies
     assert {"title": "Title E"} in friends_unique_movies
 
 
-def test_friends_unique_movies_not_duplicated():
+def test_get_friends_unique_watched_returns_list_of_movies_amanda_has_not_watched_and_friends_have_with_only_one_friend():
     # Arrange
     amandas_data = {
         "watched": [],
@@ -184,7 +182,7 @@ def test_friends_unique_movies_not_duplicated():
     assert {"title": "Title C"} in friends_unique_movies
 
 
-def test_friends_not_unique_movies():
+def test_get_friends_unique_watched_returns_empty_list_when_amanda_has_seen_all_movies_their_friend_has_seen():
     # Arrange
     amandas_data = {
         "watched": [

--- a/tests/test_wave_04.py
+++ b/tests/test_wave_04.py
@@ -2,7 +2,7 @@ import pytest
 from viewing_party.main import *
 
 
-def test_get_available_friend_rec():
+def test_get_available_recs_returns_appropriate_recommendations_for_valid_input():
     # Arrange
     amandas_data = {
         "subscriptions": ["Service A", "Service B"],
@@ -48,7 +48,7 @@ def test_get_available_friend_rec():
     assert {"title": "Title B", "host": "Service B"} in recommendations
 
 
-def test_no_available_friend_recs():
+def test_get_available_recs_returns_empty_list_for_valid_input_with_no_intersection_in_subscriptions():
     # Arrange
     amandas_data = {
         "subscriptions": ["Service A", "Service B"],

--- a/tests/test_wave_05.py
+++ b/tests/test_wave_05.py
@@ -2,7 +2,7 @@ import pytest
 from viewing_party.main import *
 
 
-def test_new_genre_rec():
+def test_get_new_rec_by_genre_():
     # Arrange
     sonyas_data = {
         "watched": [
@@ -54,7 +54,7 @@ def test_new_genre_rec():
     assert {"title": "Title E", "genre": "Intrigue"} in recommendations
 
 
-def test_new_genre_rec_from_empty_watched():
+def test_get_new_rec_by_genre_returns_empty_list_when_sonyas_watched_list_is_empty():
     # Arrange
     sonyas_data = {
         "watched": [],
@@ -89,7 +89,7 @@ def test_new_genre_rec_from_empty_watched():
     assert len(recommendations) is 0
 
 
-def test_new_genre_rec_from_empty_friends():
+def test_get_new_rec_by_genre_returns_empty_list_when_friends_watched_lists_are_empty():
     # Arrange
     sonyas_data = {
         "watched": [
@@ -115,7 +115,42 @@ def test_new_genre_rec_from_empty_friends():
     assert len(recommendations) is 0
 
 
-def test_unique_rec_from_favorites():
+def test_get_new_rec_by_genre_returns_empty_list_when_sonya_has_no_favories_and_no_unique_movie_in_watched_list():
+    # Arrange
+    sonyas_data = {
+        "watched": [],
+        "friends": [
+            {
+                "watched": [
+                    {
+                        "title": "Title A",
+                        "genre": "Intrigue"
+                    }
+                ]
+            },
+            {
+                "watched": [
+                    {
+                        "title": "Title B",
+                        "genre": "Fantasy"
+                    },
+                    {
+                        "title": "Title C",
+                        "genre": "Intrigue"
+                    }
+                ]
+            }
+        ]
+    }
+
+    # Act
+    recommendations = get_new_rec_by_genre(sonyas_data)
+
+    # Assert
+    assert len(recommendations) is 0
+
+
+def test_get_rec_from_favorites_returns_expected_list_from_valid_input():
     # Arrange
     sonyas_data = {
         "watched": [
@@ -165,63 +200,3 @@ def test_unique_rec_from_favorites():
     assert len(recommendations) is 1
     assert {"title": "Title A"} in recommendations
 
-
-def test_unique_from_empty_favorites():
-    # Arrange
-    sonyas_data = {
-        "watched": [],
-        "friends": [
-            {
-                "watched": [
-                    {
-                        "title": "Title A",
-                        "genre": "Intrigue"
-                    }
-                ]
-            },
-            {
-                "watched": [
-                    {
-                        "title": "Title B",
-                        "genre": "Fantasy"
-                    },
-                    {
-                        "title": "Title C",
-                        "genre": "Intrigue"
-                    }
-                ]
-            }
-        ]
-    }
-
-    # Act
-    recommendations = get_new_rec_by_genre(sonyas_data)
-
-    # Assert
-    assert len(recommendations) is 0
-
-
-def test_new_rec_from_empty_friends():
-    # Arrange
-    sonyas_data = {
-        "watched": [
-            {
-                "title": "Title A",
-                "genre": "Intrigue"
-            }
-        ],
-        "friends": [
-            {
-                "watched": []
-            },
-            {
-                "watched": []
-            }
-        ]
-    }
-
-    # Act
-    recommendations = get_new_rec_by_genre(sonyas_data)
-
-    # Assert
-    assert len(recommendations) is 0

--- a/tests/test_wave_05.py
+++ b/tests/test_wave_05.py
@@ -115,41 +115,6 @@ def test_get_new_rec_by_genre_returns_empty_list_when_friends_watched_lists_are_
     assert len(recommendations) is 0
 
 
-def test_get_new_rec_by_genre_returns_empty_list_when_sonya_has_no_favories_and_no_unique_movie_in_watched_list():
-    # Arrange
-    sonyas_data = {
-        "watched": [],
-        "friends": [
-            {
-                "watched": [
-                    {
-                        "title": "Title A",
-                        "genre": "Intrigue"
-                    }
-                ]
-            },
-            {
-                "watched": [
-                    {
-                        "title": "Title B",
-                        "genre": "Fantasy"
-                    },
-                    {
-                        "title": "Title C",
-                        "genre": "Intrigue"
-                    }
-                ]
-            }
-        ]
-    }
-
-    # Act
-    recommendations = get_new_rec_by_genre(sonyas_data)
-
-    # Assert
-    assert len(recommendations) is 0
-
-
 def test_get_rec_from_favorites_returns_expected_list_from_valid_input():
     # Arrange
     sonyas_data = {
@@ -199,4 +164,40 @@ def test_get_rec_from_favorites_returns_expected_list_from_valid_input():
     # Assert
     assert len(recommendations) is 1
     assert {"title": "Title A"} in recommendations
+
+
+
+def test_get_new_rec_by_genre_returns_empty_list_when_sonya_has_no_favories_and_no_unique_movie_in_watched_list():
+    # Arrange
+    sonyas_data = {
+        "watched": [],
+        "friends": [
+            {
+                "watched": [
+                    {
+                        "title": "Title A",
+                        "genre": "Intrigue"
+                    }
+                ]
+            },
+            {
+                "watched": [
+                    {
+                        "title": "Title B",
+                        "genre": "Fantasy"
+                    },
+                    {
+                        "title": "Title C",
+                        "genre": "Intrigue"
+                    }
+                ]
+            }
+        ]
+    }
+
+    # Act
+    recommendations = get_new_rec_by_genre(sonyas_data)
+
+    # Assert
+    assert len(recommendations) is 0
 

--- a/tests/test_wave_05.py
+++ b/tests/test_wave_05.py
@@ -115,6 +115,42 @@ def test_get_new_rec_by_genre_returns_empty_list_when_friends_watched_lists_are_
     assert len(recommendations) is 0
 
 
+
+def test_get_new_rec_by_genre_returns_empty_list_when_sonya_has_no_favories_and_no_unique_movie_in_watched_list():
+    # Arrange
+    sonyas_data = {
+        "watched": [],
+        "friends": [
+            {
+                "watched": [
+                    {
+                        "title": "Title A",
+                        "genre": "Intrigue"
+                    }
+                ]
+            },
+            {
+                "watched": [
+                    {
+                        "title": "Title B",
+                        "genre": "Fantasy"
+                    },
+                    {
+                        "title": "Title C",
+                        "genre": "Intrigue"
+                    }
+                ]
+            }
+        ]
+    }
+
+    # Act
+    recommendations = get_new_rec_by_genre(sonyas_data)
+
+    # Assert
+    assert len(recommendations) is 0
+
+
 def test_get_rec_from_favorites_returns_expected_list_from_valid_input():
     # Arrange
     sonyas_data = {
@@ -164,40 +200,3 @@ def test_get_rec_from_favorites_returns_expected_list_from_valid_input():
     # Assert
     assert len(recommendations) is 1
     assert {"title": "Title A"} in recommendations
-
-
-
-def test_get_new_rec_by_genre_returns_empty_list_when_sonya_has_no_favories_and_no_unique_movie_in_watched_list():
-    # Arrange
-    sonyas_data = {
-        "watched": [],
-        "friends": [
-            {
-                "watched": [
-                    {
-                        "title": "Title A",
-                        "genre": "Intrigue"
-                    }
-                ]
-            },
-            {
-                "watched": [
-                    {
-                        "title": "Title B",
-                        "genre": "Fantasy"
-                    },
-                    {
-                        "title": "Title C",
-                        "genre": "Intrigue"
-                    }
-                ]
-            }
-        ]
-    }
-
-    # Act
-    recommendations = get_new_rec_by_genre(sonyas_data)
-
-    # Assert
-    assert len(recommendations) is 0
-


### PR DESCRIPTION
In the curriculum that we tell them:
“For each test case, the best test names usually include:
- the name of the tested function
- context (possibly the kinds of arguments)
- its expected outcome (usually the return value)”

This change is to align these tests with that guidance and hopefully make them much easier for students to understand when they fail.

I did do two things in addition to renaming:
- In wave 3, I changed a test slightly to make it a more interesting, unique test case
- In wave 5, I removed a test because it was identical to another one in everything but its name


I have tested this against our (Simon's) solution and confirmed that all tests pass locally. Will test on Learn as soon as I can figure that out.


In wave 5, there's a weirdness where there's a test for `get_rec_from_favorites` then it goes back to testing `get_new_rec_by_genre`. I originally wanted to move the favorites test to the bottom, but it was hard to read in the diff so I put it back. If this gets approved, I may ask the reviewer if they're cool with me moving that test