### PR TITLE
Ar/frequent genre test revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ In `party.py`, there should be a function named `get_watched_avg_rating`. This f
   - The average rating of an empty watched list is `0.0`
 - return the average rating
 
-1. The next three tests are about a `get_most_watched_genre()` function.
+2. The next three tests are about a `get_most_watched_genre()` function.
 
 In `party.py`, there should be a function named `get_most_watched_genre`. This function should...
 

--- a/README.md
+++ b/README.md
@@ -147,14 +147,14 @@ $ pytest tests/test_file_name.py
 
 ## Project Write-Up: How to Complete and Submit
 
-The goal of this project is to write code in `main.py` so that as many of the tests pass as possible.
+The goal of this project is to write code in `party.py` so that as many of the tests pass as possible.
 
 To complete this project, use the above workflow and follow these steps:
 
 1. Start with making the tests in `test_wave_01.py` pass.
-1. Review your code in `main.py` and see if there are ways you can make the code more readable.
+1. Review your code in `party.py` and see if there are ways you can make the code more readable.
 1. Then, work on making the tests in `test_wave_02.py` pass.
-1. Review your code in `main.py`
+1. Review your code in `party.py`
 1. Repeat on all test files until submission time.
 
 At submission time, no matter where you are, submit the project via Learn.
@@ -169,7 +169,7 @@ When our test failures leave us confused and stuck, let's use the detailed proje
 
 1. The first four tests are about a `create_movie()` function.
 
-In `main.py`, there should be a function named `create_movie`. This function should...
+In `party.py`, there should be a function named `create_movie`. This function should...
 
 - take three parameters: `title`, `genre`, `rating`
 - If those there attributes are truthy, then return a dictionary. This dictionary should...
@@ -180,7 +180,7 @@ In `main.py`, there should be a function named `create_movie`. This function sho
 
 2. The next test is about a `add_to_watched()` function.
 
-In `main.py`, there should be a function named `add_to_watched`. This function should...
+In `party.py`, there should be a function named `add_to_watched`. This function should...
 
 - take two parameters: `user_data`, `movie`
   - the value of `user_data` will be a dictionary with a key `"watched"`, and a value `[]`
@@ -198,7 +198,7 @@ In `main.py`, there should be a function named `add_to_watched`. This function s
 
 3. The next test is about a `add_to_watchlist()` function.
 
-In `main.py`, there should be a function named `add_to_watchlist`. This function should...
+In `party.py`, there should be a function named `add_to_watchlist`. This function should...
 
 - take two parameters: `user_data`, `movie`
   - the value of `user_data` will be a dictionary with a key `"watchlist"`, and a value `[]`
@@ -216,7 +216,7 @@ In `main.py`, there should be a function named `add_to_watchlist`. This function
 
 4. There are three tests about a `watch_movie()` function.
 
-In `main.py`, there should be a function named `watch_movie`. This function should...
+In `party.py`, there should be a function named `watch_movie`. This function should...
 
 - take two parameters: `user_data`, `title`
   - the value of `user_data` will be a dictionary with a `"watchlist"` and a `"watched"`
@@ -234,7 +234,7 @@ In `main.py`, there should be a function named `watch_movie`. This function shou
 
 1. The first two tests are about a `get_watched_avg_rating()` function.
 
-In `main.py`, there should be a function named `get_watched_avg_rating`. This function should...
+In `party.py`, there should be a function named `get_watched_avg_rating`. This function should...
 
 - take one parameter: `user_data`
   - the value of `user_data` will be a dictionary with a `"watched"` list of movie dictionaries
@@ -245,7 +245,7 @@ In `main.py`, there should be a function named `get_watched_avg_rating`. This fu
 
 2. The next two tests are about a `get_most_watched_genre()` function.
 
-In `main.py`, there should be a function named `get_most_watched_genre`. This function should...
+In `party.py`, there should be a function named `get_most_watched_genre`. This function should...
 
 - take one parameter: `user_data`
   - the value of `user_data` will be a dictionary with a `"watched"` list of movie dictionaries. Each movie dictionary has a key `"genre"`.
@@ -258,7 +258,7 @@ In `main.py`, there should be a function named `get_most_watched_genre`. This fu
 
 1. The first two tests are about a `get_unique_watched()` function.
 
-In `main.py`, there should be a function named `get_unique_watched`. This function should...
+In `party.py`, there should be a function named `get_unique_watched`. This function should...
 
 - take one parameter: `user_data`
   - the value of `user_data` will be a dictionary with a `"watched"` list of movie dictionaries, and a `"friends"`
@@ -271,7 +271,7 @@ In `main.py`, there should be a function named `get_unique_watched`. This functi
 
 2. The next three tests are about a `get_friends_unique_watched()` function.
 
-In `main.py`, there should be a function named `get_friends_unique_watched`. This function should...
+In `party.py`, there should be a function named `get_friends_unique_watched`. This function should...
 
 - take one parameter: `user_data`
   - the value of `user_data` will be a dictionary with a `"watched"` list of movie dictionaries, and a `"friends"`

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ In `party.py`, there should be a function named `get_watched_avg_rating`. This f
   - The average rating of an empty watched list is `0.0`
 - return the average rating
 
-2. The next two tests are about a `get_most_watched_genre()` function.
+1. The next three tests are about a `get_most_watched_genre()` function.
 
 In `party.py`, there should be a function named `get_most_watched_genre`. This function should...
 

--- a/tests/test_wave_01.py
+++ b/tests/test_wave_01.py
@@ -13,9 +13,9 @@ def test_create_movie_all_params_valid_returns_movie():
     new_movie = create_movie(movie_title, genre, rating)
 
     # Assert
-    assert new_movie["title"] is "Title A"
-    assert new_movie["genre"] is "Horror"
-    assert new_movie["rating"] is 3.5
+    assert new_movie["title"] == "Title A"
+    assert new_movie["genre"] == "Horror"
+    assert new_movie["rating"] == 3.5
 
 
 def test_create_movie_no_title_returns_none():
@@ -72,10 +72,10 @@ def test_add_to_watched_adds_movie_to_user_watched():
     updated_data = add_to_watched(user_data, movie)
 
     # Assert
-    assert len(updated_data["watched"]) is 1
-    assert updated_data["watched"][0]["title"] is "Title A"
-    assert updated_data["watched"][0]["genre"] is "Horror"
-    assert updated_data["watched"][0]["rating"] is 3.5
+    assert len(updated_data["watched"]) == 1
+    assert updated_data["watched"][0]["title"] == "Title A"
+    assert updated_data["watched"][0]["genre"] == "Horror"
+    assert updated_data["watched"][0]["rating"] == 3.5
 
 
 def test_add_to_watchlist_adds_movie_to_user_watchlist():
@@ -93,10 +93,10 @@ def test_add_to_watchlist_adds_movie_to_user_watchlist():
     updated_data = add_to_watchlist(user_data, movie)
 
     # Assert
-    assert len(updated_data["watchlist"]) is 1
-    assert updated_data["watchlist"][0]["title"] is "Title A"
-    assert updated_data["watchlist"][0]["genre"] is "Horror"
-    assert updated_data["watchlist"][0]["rating"] is 3.5
+    assert len(updated_data["watchlist"]) == 1
+    assert updated_data["watchlist"][0]["title"] == "Title A"
+    assert updated_data["watchlist"][0]["genre"] == "Horror"
+    assert updated_data["watchlist"][0]["rating"] == 3.5
 
 
 def test_watch_movie_moves_movie_from_watchlist_to_empty_watched():
@@ -114,11 +114,11 @@ def test_watch_movie_moves_movie_from_watchlist_to_empty_watched():
     updated_data = watch_movie(janes_data, "Title A")
 
     # Assert
-    assert len(updated_data["watchlist"]) is 0
-    assert len(updated_data["watched"]) is 1
-    assert updated_data["watched"][0]["title"] is "Title A"
-    assert updated_data["watched"][0]["genre"] is "Fantasy"
-    assert updated_data["watched"][0]["rating"] is 4.8
+    assert len(updated_data["watchlist"]) == 0
+    assert len(updated_data["watched"]) == 1
+    assert updated_data["watched"][0]["title"] == "Title A"
+    assert updated_data["watched"][0]["genre"] == "Fantasy"
+    assert updated_data["watched"][0]["rating"] == 4.8
 
 
 def test_watch_movie_moves_movie_from_watchlist_to_watched():
@@ -150,8 +150,8 @@ def test_watch_movie_moves_movie_from_watchlist_to_watched():
     updated_data = watch_movie(janes_data, movie_to_watch["title"])
 
     # Assert
-    assert len(updated_data["watchlist"]) is 1
-    assert len(updated_data["watched"]) is 2
+    assert len(updated_data["watchlist"]) == 1
+    assert len(updated_data["watched"]) == 2
     assert movie_to_watch in updated_data["watched"]
 
 
@@ -183,7 +183,7 @@ def test_watch_movie_does_nothing_if_movie_not_in_watchlist():
     updated_data = watch_movie(janes_data, "Title A")
 
     # Assert
-    assert len(updated_data["watchlist"]) is 1
-    assert len(updated_data["watched"]) is 1
+    assert len(updated_data["watchlist"]) == 1
+    assert len(updated_data["watched"]) == 1
     assert movie_to_watch not in updated_data["watchlist"]
     assert movie_to_watch not in updated_data["watched"]

--- a/tests/test_wave_01.py
+++ b/tests/test_wave_01.py
@@ -1,6 +1,6 @@
 import pytest
 # NOTE: In production code, we developers should change import * to something more specific. Due to some constraints of this project, we will import * in our test files.
-from viewing_party.main import *
+from viewing_party.party import *
 
 
 def test_create_movie_all_params_valid_returns_movie():

--- a/tests/test_wave_02.py
+++ b/tests/test_wave_02.py
@@ -78,6 +78,38 @@ def test_get_most_watched_genre_returns_most_frequent_genre_from_list():
     # Assert
     assert popular_genre == "Intrigue"
 
+def test_get_most_watched_genre_returns_most_frequent_genre_from_list_even_when_alphabetically_smaller():
+    # Arrange
+    janes_data = {
+        "watched": [
+            {
+                "title": "Title A",
+                "genre": "Fantasy"
+            },
+            {
+                "title": "Title B",
+                "genre": "Action"
+            },
+            {
+                "title": "Title C",
+                "genre": "Action"
+            },
+            {
+                "title": "Title D",
+                "genre": "Fantasy"
+            },
+            {
+                "title": "Title E",
+                "genre": "Action"
+            },
+        ]
+    }
+
+    # Act
+    popular_genre = get_most_watched_genre(janes_data)
+
+    # Assert
+    assert popular_genre == "Action"
 
 def test_get_most_watched_genre_returns_None_if_empty_watched():
     # Arrange

--- a/tests/test_wave_02.py
+++ b/tests/test_wave_02.py
@@ -76,7 +76,7 @@ def test_get_most_watched_genre_returns_most_frequent_genre_from_list():
     popular_genre = get_most_watched_genre(janes_data)
 
     # Assert
-    assert popular_genre is "Intrigue"
+    assert popular_genre == "Intrigue"
 
 
 def test_get_most_watched_genre_returns_None_if_empty_watched():

--- a/tests/test_wave_02.py
+++ b/tests/test_wave_02.py
@@ -1,5 +1,5 @@
 import pytest
-from viewing_party.main import *
+from viewing_party.party import *
 
 
 def test_get_watched_avg_rating_calculates_watched_average_rating():

--- a/tests/test_wave_03.py
+++ b/tests/test_wave_03.py
@@ -53,7 +53,7 @@ def test_get_unique_watched_returns_list_of_movies_in_amandas_data_absent_from_t
     amandas_unique_movies = get_unique_watched(amandas_data)
 
     # Assert
-    assert len(amandas_unique_movies) is 2
+    assert len(amandas_unique_movies) == 2
     assert {"title": "Title B"} in amandas_unique_movies
     assert {"title": "Title E"} in amandas_unique_movies
 
@@ -93,7 +93,7 @@ def test_get_unique_watched_returns_empty_list_when_amandas_movies_are_all_in_he
     amandas_unique_movies = get_unique_watched(amandas_data)
 
     # Assert
-    assert len(amandas_unique_movies) is 0
+    assert len(amandas_unique_movies) == 0
 
 
 def test_get_friends_unique_watched_returns_list_of_movies_amanda_has_not_watched_and_friends_have_but_does_not_include_two_of_the_same_movie():
@@ -138,7 +138,7 @@ def test_get_friends_unique_watched_returns_list_of_movies_amanda_has_not_watche
     friends_unique_movies = get_friends_unique_watched(amandas_data)
 
     # Assert
-    assert len(friends_unique_movies) is 3
+    assert len(friends_unique_movies) == 3
     assert {"title": "Title A"} in friends_unique_movies
     assert {"title": "Title D"} in friends_unique_movies
     assert {"title": "Title E"} in friends_unique_movies
@@ -176,7 +176,7 @@ def test_get_friends_unique_watched_returns_list_of_movies_amanda_has_not_watche
     friends_unique_movies = get_friends_unique_watched(amandas_data)
 
     # Assert
-    assert len(friends_unique_movies) is 3
+    assert len(friends_unique_movies) == 3
     assert {"title": "Title A"} in friends_unique_movies
     assert {"title": "Title B"} in friends_unique_movies
     assert {"title": "Title C"} in friends_unique_movies
@@ -217,4 +217,4 @@ def test_get_friends_unique_watched_returns_empty_list_when_amanda_has_seen_all_
     friends_unique_movies = get_friends_unique_watched(amandas_data)
 
     # Assert
-    assert len(friends_unique_movies) is 0
+    assert len(friends_unique_movies) == 0

--- a/tests/test_wave_03.py
+++ b/tests/test_wave_03.py
@@ -1,5 +1,5 @@
 import pytest
-from viewing_party.main import *
+from viewing_party.party import *
 
 
 def test_get_unique_watched_returns_list_of_movies_in_amandas_data_absent_from_their_friends_data():

--- a/tests/test_wave_04.py
+++ b/tests/test_wave_04.py
@@ -43,7 +43,7 @@ def test_get_available_recs_returns_appropriate_recommendations_for_valid_input(
     recommendations = get_available_recs(amandas_data)
 
     # Assert
-    assert len(recommendations) is 2
+    assert len(recommendations) == 2
     assert {"title": "Title A", "host": "Service A"} in recommendations
     assert {"title": "Title B", "host": "Service B"} in recommendations
 
@@ -77,4 +77,4 @@ def test_get_available_recs_returns_empty_list_for_valid_input_with_no_intersect
     recommendations = get_available_recs(amandas_data)
 
     # Assert
-    assert len(recommendations) is 0
+    assert len(recommendations) == 0

--- a/tests/test_wave_04.py
+++ b/tests/test_wave_04.py
@@ -1,5 +1,5 @@
 import pytest
-from viewing_party.main import *
+from viewing_party.party import *
 
 
 def test_get_available_recs_returns_appropriate_recommendations_for_valid_input():

--- a/tests/test_wave_05.py
+++ b/tests/test_wave_05.py
@@ -1,5 +1,5 @@
 import pytest
-from viewing_party.main import *
+from viewing_party.party import *
 
 
 def test_get_new_rec_by_genre_returns_appropriate_recommendations_for_large_amount_of_valid_input():

--- a/tests/test_wave_05.py
+++ b/tests/test_wave_05.py
@@ -49,7 +49,7 @@ def test_get_new_rec_by_genre_returns_appropriate_recommendations_for_large_amou
     # Assert
     for rec in recommendations:
         assert rec not in sonyas_data["watched"]
-    assert len(recommendations) is 2
+    assert len(recommendations) == 2
     assert {"title": "Title D", "genre": "Intrigue"} in recommendations
     assert {"title": "Title E", "genre": "Intrigue"} in recommendations
 
@@ -86,7 +86,7 @@ def test_get_new_rec_by_genre_returns_empty_list_when_sonyas_watched_list_is_emp
     recommendations = get_new_rec_by_genre(sonyas_data)
 
     # Assert
-    assert len(recommendations) is 0
+    assert len(recommendations) == 0
 
 
 def test_get_new_rec_by_genre_returns_empty_list_when_friends_watched_lists_are_empty():
@@ -112,7 +112,7 @@ def test_get_new_rec_by_genre_returns_empty_list_when_friends_watched_lists_are_
     recommendations = get_new_rec_by_genre(sonyas_data)
 
     # Assert
-    assert len(recommendations) is 0
+    assert len(recommendations) == 0
 
 
 
@@ -148,7 +148,7 @@ def test_get_new_rec_by_genre_returns_empty_list_when_sonya_has_no_favories_and_
     recommendations = get_new_rec_by_genre(sonyas_data)
 
     # Assert
-    assert len(recommendations) is 0
+    assert len(recommendations) == 0
 
 
 def test_get_rec_from_favorites_returns_expected_list_from_valid_input():
@@ -198,5 +198,5 @@ def test_get_rec_from_favorites_returns_expected_list_from_valid_input():
     recommendations = get_rec_from_favorites(sonyas_data)
 
     # Assert
-    assert len(recommendations) is 1
+    assert len(recommendations) == 1
     assert {"title": "Title A"} in recommendations


### PR DESCRIPTION
1. renames main.py to party.py since the main is just a library file, not the main entry point (attempt to avoid forming strange associations with main)
    1. updates readme to reflect new file name
2. updates tests to use == instead of `is` for all primitive comparisons (int and str)
3. adds additional test for most frequent genre to prevent stumbling on an incorrect solution
    1. adding this test revealed an error in my own "solution"!
    2. updates readme to reflect new test count

This change was tested by
1. fork from adagold to ada-c15a (will be deleted after merge)
2. apply proposed changes to master there so that learn can use it
3. fork from ada-c15a to anselrognlie to provide an implementation for party.py with c15a as an upstream
4. create feature branch in core-projects where I updated the upstream for the submission to c15a
5. published to sandbox with core-projects pointing at feature branch
6. "submitted" anselrognlie to learn sandbox
7. tests passed (26 count). the adagold currently has 25 tests, so the new test was being checked!