### PR TITLE
updating tests for viewing party (in-progress)

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Create a function named `get_new_rec_by_genre`
   - The `"genre"` of the movie is the same as the user's most frequent genre
 - Return the list of recommended movies
 
-2. There is also one test about a `get_rec_from_favorites` function
+2. There are also two tests about a `get_rec_from_favorites` function
 
 Create a function named `get_rec_from_favorites`
 

--- a/README.md
+++ b/README.md
@@ -172,19 +172,19 @@ When our test failures leave us confused and stuck, let's use the detailed proje
 In `party.py`, there should be a function named `create_movie`. This function should...
 
 - take three parameters: `title`, `genre`, `rating`
-- If those there attributes are truthy, then return a dictionary. This dictionary should...
+- If those three attributes are truthy, then return a dictionary. This dictionary should...
   - Have three key-value pairs, with specific keys
   - The three keys should be `"title"`, `"genre"`, and `"rating"`
   - The values of these key-value pairs should be appropriate values
 - If `title` is falsy, `genre` is falsy, or `rating` is falsy, this function should return `None`
 
-2. The next test is about a `add_to_watched()` function.
+2. The next two tests are about an `add_to_watched()` function.
 
 In `party.py`, there should be a function named `add_to_watched`. This function should...
 
 - take two parameters: `user_data`, `movie`
-  - the value of `user_data` will be a dictionary with a key `"watched"`, and a value `[]`
-    - This represents that the user has no movies in their watched list
+  - the value of `user_data` will be a dictionary with a key `"watched"`, and a value which is a list of dictionaries representing the movies the user has watched
+    - An empty list represents that the user has no movies in their watched list
   - the value of `movie` will be a dictionary in this format:
     - ```python
       {
@@ -196,13 +196,13 @@ In `party.py`, there should be a function named `add_to_watched`. This function 
 - add the `movie` to the `"watched"` list inside of `user_data`
 - return the `user_data`
 
-3. The next test is about a `add_to_watchlist()` function.
+3. The next two tests are about an `add_to_watchlist()` function.
 
 In `party.py`, there should be a function named `add_to_watchlist`. This function should...
 
 - take two parameters: `user_data`, `movie`
-  - the value of `user_data` will be a dictionary with a key `"watchlist"`, and a value `[]`
-    - This represents that the user has no movies in their watchlist
+  - the value of `user_data` will be a dictionary with a key `"watchlist"`, and a value which is a list of dictionaries representing the movies the user wants to watch
+    - An empty list represents that the user has no movies in their watchlist
   - the value of `movie` will be a dictionary in this format:
     - ```python
       {

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ In `party.py`, there should be a function named `get_friends_unique_watched`. Th
 
 ### Wave 4
 
-1. There are two tests about a `get_available_recs` function
+1. There are four tests about a `get_available_recs` function
 
 Create a function named `get_available_recs`
 

--- a/tests/test_wave_01.py
+++ b/tests/test_wave_01.py
@@ -72,10 +72,42 @@ def test_add_to_watched_adds_movie_to_user_watched():
     updated_data = add_to_watched(user_data, movie)
 
     # Assert
+    assert id(updated_data) == id(user_data)
     assert len(updated_data["watched"]) == 1
     assert updated_data["watched"][0]["title"] == "Title A"
     assert updated_data["watched"][0]["genre"] == "Horror"
     assert updated_data["watched"][0]["rating"] == 3.5
+    assert id(updated_data["watched"][0]) == id(movie)
+
+
+def test_add_to_nonempty_watched_adds_movie_to_user_watched():
+    # Arrange
+    movie = {
+        "title": "Title B",
+        "genre": "Adventure",
+        "rating": 2.0
+    }
+    user_data = {
+        "watched": [{
+            "title": "Title A",
+            "genre": "Horror",
+            "rating": 3.5
+        }]
+    }
+
+    # Act
+    updated_data = add_to_watched(user_data, movie)
+
+    # Assert
+    assert id(updated_data) == id(user_data)
+    assert len(updated_data["watched"]) == 2
+    assert updated_data["watched"][0]["title"] == "Title A"
+    assert updated_data["watched"][0]["genre"] == "Horror"
+    assert updated_data["watched"][0]["rating"] == 3.5
+    assert updated_data["watched"][1]["title"] == "Title B"
+    assert updated_data["watched"][1]["genre"] == "Adventure"
+    assert updated_data["watched"][1]["rating"] == 2.0
+    assert id(updated_data["watched"][1]) == id(movie)
 
 
 def test_add_to_watchlist_adds_movie_to_user_watchlist():
@@ -93,10 +125,42 @@ def test_add_to_watchlist_adds_movie_to_user_watchlist():
     updated_data = add_to_watchlist(user_data, movie)
 
     # Assert
+    assert id(updated_data) == id(user_data)
     assert len(updated_data["watchlist"]) == 1
     assert updated_data["watchlist"][0]["title"] == "Title A"
     assert updated_data["watchlist"][0]["genre"] == "Horror"
     assert updated_data["watchlist"][0]["rating"] == 3.5
+    assert id(updated_data["watchlist"][0]) == id(movie)
+
+
+def test_add_to_nonempty_watchlist_adds_movie_to_user_watchlist():
+    # Arrange
+    movie = {
+        "title": "Title B",
+        "genre": "Adventure",
+        "rating": 2.0
+    }
+    user_data = {
+        "watchlist": [{
+            "title": "Title A",
+            "genre": "Horror",
+            "rating": 3.5
+        }]
+    }
+
+    # Act
+    updated_data = add_to_watchlist(user_data, movie)
+
+    # Assert
+    assert id(updated_data) == id(user_data)
+    assert len(updated_data["watchlist"]) == 2
+    assert updated_data["watchlist"][0]["title"] == "Title A"
+    assert updated_data["watchlist"][0]["genre"] == "Horror"
+    assert updated_data["watchlist"][0]["rating"] == 3.5
+    assert updated_data["watchlist"][1]["title"] == "Title B"
+    assert updated_data["watchlist"][1]["genre"] == "Adventure"
+    assert updated_data["watchlist"][1]["rating"] == 2.0
+    assert id(updated_data["watchlist"][1]) == id(movie)
 
 
 def test_watch_movie_moves_movie_from_watchlist_to_empty_watched():
@@ -153,6 +217,7 @@ def test_watch_movie_moves_movie_from_watchlist_to_watched():
     assert len(updated_data["watchlist"]) == 1
     assert len(updated_data["watched"]) == 2
     assert movie_to_watch in updated_data["watched"]
+    assert movie_to_watch not in updated_data["watchlist"]
 
 
 def test_watch_movie_does_nothing_if_movie_not_in_watchlist():

--- a/tests/test_wave_04.py
+++ b/tests/test_wave_04.py
@@ -48,6 +48,95 @@ def test_get_available_recs_returns_appropriate_recommendations_for_valid_input(
     assert {"title": "Title B", "host": "Service B"} in recommendations
 
 
+def test_get_available_recs_doesnt_recommend_watched_movie():
+    # Arrange
+    amandas_data = {
+        "subscriptions": ["Service A", "Service B"],
+        "watched": [{ "title": "Title A" }],
+        "friends": [
+            {
+                "watched": [
+                    {
+                        "title": "Title A",
+                        "host": "Service A"
+                    },
+                    {
+                        "title": "Title C",
+                        "host": "Service C"
+                    }
+                ]
+            },
+            {
+                "watched": [
+                    {
+                        "title": "Title A",
+                        "host": "Service A"
+                    },
+                    {
+                        "title": "Title B",
+                        "host": "Service B"
+                    },
+                    {
+                        "title": "Title D",
+                        "host": "Service D"
+                    }
+                ]
+            }
+        ]
+    }
+
+    # Act
+    recommendations = get_available_recs(amandas_data)
+
+    # Arrange
+    assert len(recommendations) == 1
+    assert {"title": "Title B", "host": "Service B"} in recommendations
+
+
+def test_get_available_recs_returns_nothing_if_all_watched():
+    # Arrange
+    amandas_data = {
+        "subscriptions": ["Service A", "Service B"],
+        "watched": [{ "title": "Title A" }, { "title": "Title B" }],
+        "friends": [
+            {
+                "watched": [
+                    {
+                        "title": "Title A",
+                        "host": "Service A"
+                    },
+                    {
+                        "title": "Title C",
+                        "host": "Service C"
+                    }
+                ]
+            },
+            {
+                "watched": [
+                    {
+                        "title": "Title A",
+                        "host": "Service A"
+                    },
+                    {
+                        "title": "Title B",
+                        "host": "Service B"
+                    },
+                    {
+                        "title": "Title D",
+                        "host": "Service D"
+                    }
+                ]
+            }
+        ]
+    }
+
+    # Act
+    recommendations = get_available_recs(amandas_data)
+
+    # Arrange
+    assert len(recommendations) == 0
+
+
 def test_get_available_recs_returns_empty_list_for_valid_input_with_no_intersection_in_subscriptions():
     # Arrange
     amandas_data = {

--- a/tests/test_wave_05.py
+++ b/tests/test_wave_05.py
@@ -54,6 +54,62 @@ def test_get_new_rec_by_genre_returns_appropriate_recommendations_for_large_amou
     assert {"title": "Title E", "genre": "Intrigue"} in recommendations
 
 
+def test_get_new_rec_by_genre_doesnt_return_duplicate_recommendations_if_watched_by_multiple_friends():
+    # Arrange
+    sonyas_data = {
+        "watched": [
+            {
+                "title": "Title A",
+                "genre": "Intrigue"
+            },
+            {
+                "title": "Title B",
+                "genre": "Intrigue"
+            },
+            {
+                "title": "Title C",
+                "genre": "Fantasy"
+            }
+        ],
+        "friends": [
+            {
+                "watched": [
+                    {
+                        "title": "Title D",
+                        "genre": "Intrigue"
+                    },
+                    {
+                        "title": "Title E",
+                        "genre": "Intrigue"
+                    }
+                ]
+            },
+            {
+                "watched": [
+                    {
+                        "title": "Title D",
+                        "genre": "Intrigue"
+                    },
+                    {
+                        "title": "Title E",
+                        "genre": "Intrigue"
+                    }
+                ]
+            }
+        ]
+    }
+
+    # Act
+    recommendations = get_new_rec_by_genre(sonyas_data)
+
+    # Assert
+    for rec in recommendations:
+        assert rec not in sonyas_data["watched"]
+    assert len(recommendations) == 2
+    assert {"title": "Title D", "genre": "Intrigue"} in recommendations
+    assert {"title": "Title E", "genre": "Intrigue"} in recommendations
+
+
 def test_get_new_rec_by_genre_returns_empty_list_when_sonyas_watched_list_is_empty():
     # Arrange
     sonyas_data = {
@@ -116,10 +172,11 @@ def test_get_new_rec_by_genre_returns_empty_list_when_friends_watched_lists_are_
 
 
 
-def test_get_new_rec_by_genre_returns_empty_list_when_sonya_has_no_favories_and_no_unique_movie_in_watched_list():
+def test_get_rec_from_favorites_returns_empty_list_when_sonya_has_no_favorites():
     # Arrange
     sonyas_data = {
         "watched": [],
+        "favorites": [],
         "friends": [
             {
                 "watched": [
@@ -145,7 +202,7 @@ def test_get_new_rec_by_genre_returns_empty_list_when_sonya_has_no_favories_and_
     }
 
     # Act
-    recommendations = get_new_rec_by_genre(sonyas_data)
+    recommendations = get_rec_from_favorites(sonyas_data)
 
     # Assert
     assert len(recommendations) == 0


### PR DESCRIPTION
makes the following updates (to wave tests and README.md)

wave 1:
validates add_to_watched when the watched list already has data
validates add_to_watchlist when the watchlist already has data
add_to_watched and add_to_watchlist both return the user_data, so check that it's the same object
*questionable* both functions add the movie to the appropriate list, so check it is the same instance
test_watch_movie_moves_movie_from_watchlist_to_watched checks that the movie moved to the watched list is no longer in the watchlist

wave 4:
make sure get_available_recs doesn't recommend a movie the user has already watched

wave 5:
updates test_get_new_rec_by_genre_returns_empty_list_when_sonya_has_no_favories_and_no_unique_movie_in_watched_list to test get_rec_from_favorites (also renamed)
checks that get_new_rec_by_genre doesn't add duplicate movies to the recommendations list