### PR TITLE
Test corrections and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,7 @@ When our test failures leave us confused and stuck, let's use the detailed proje
 
 ### Wave 1
 
-1. The first four tests are about a `create_movie()` function.
-
-In `party.py`, there should be a function named `create_movie`. This function should...
+1. Create a function named  `create_movie`. This function and all subsequent functions should be in `party.py`. `create_movie` should...
 
 - take three parameters: `title`, `genre`, `rating`
 - If those three attributes are truthy, then return a dictionary. This dictionary should...
@@ -213,9 +211,7 @@ In `party.py`, there should be a function named `create_movie`. This function sh
   - The values of these key-value pairs should be appropriate values
 - If `title` is falsy, `genre` is falsy, or `rating` is falsy, this function should return `None`
 
-2. The next two tests are about the `add_to_watched()` function.
-
-In `party.py`, there should be a function named `add_to_watched`. This function should...
+2. Create a function named `add_to_watched`. This function should...
 
 - take two parameters: `user_data`, `movie`
   - the value of `user_data` will be a dictionary with a key `"watched"`, and a value which is a list of dictionaries representing the movies the user has watched
@@ -231,9 +227,7 @@ In `party.py`, there should be a function named `add_to_watched`. This function 
 - add the `movie` to the `"watched"` list inside of `user_data`
 - return the `user_data`
 
-3. The next two tests are about an `add_to_watchlist()` function.
-
-In `party.py`, there should be a function named `add_to_watchlist`. This function should...
+3. Create a function named `add_to_watchlist`. This function should...
 
 - take two parameters: `user_data`, `movie`
   - the value of `user_data` will be a dictionary with a key `"watchlist"`, and a value which is a list of dictionaries representing the movies the user wants to watch
@@ -249,9 +243,7 @@ In `party.py`, there should be a function named `add_to_watchlist`. This functio
 - add the `movie` to the `"watchlist"` list inside of `user_data`
 - return the `user_data`
 
-4. There are three tests about a `watch_movie()` function.
-
-In `party.py`, there should be a function named `watch_movie`. This function should...
+4. Create a function named `watch_movie`. This function should...
 
 - take two parameters: `user_data`, `title`
   - the value of `user_data` will be a dictionary with a `"watchlist"` and a `"watched"`
@@ -269,9 +261,7 @@ Note: For Waves 2, 3, 4, and 5, your implementation of each of the functions sho
 
 ### Wave 2
 
-1. The first two tests are about a `get_watched_avg_rating()` function.
-
-In `party.py`, there should be a function named `get_watched_avg_rating`. This function should...
+1. Create a function named `get_watched_avg_rating`. This function should...
 
 - take one parameter: `user_data`
   - the value of `user_data` will be a dictionary with a `"watched"` list of movie dictionaries
@@ -280,9 +270,7 @@ In `party.py`, there should be a function named `get_watched_avg_rating`. This f
   - The average rating of an empty watched list is `0.0`
 - return the average rating
 
-2. The next three tests are about a `get_most_watched_genre()` function.
-
-In `party.py`, there should be a function named `get_most_watched_genre`. This function should...
+2. Create a function named `get_most_watched_genre`. This function should...
 
 - take one parameter: `user_data`
   - the value of `user_data` will be a dictionary with a `"watched"` list of movie dictionaries. Each movie dictionary has a key `"genre"`.
@@ -294,9 +282,7 @@ In `party.py`, there should be a function named `get_most_watched_genre`. This f
 
 ### Wave 3
 
-1. The first two tests are about a `get_unique_watched()` function.
-
-In `party.py`, there should be a function named `get_unique_watched`. This function should...
+1. Create a function named `get_unique_watched`. This function should...
 
 - take one parameter: `user_data`
   - the value of `user_data` will be a dictionary with a `"watched"` list of movie dictionaries, and a `"friends"`
@@ -307,9 +293,7 @@ In `party.py`, there should be a function named `get_unique_watched`. This funct
 - Consider the movies that the user has watched, and consider the movies that their friends have watched. Determine which movies the user has watched, but none of their friends have watched.
 - Return a list of dictionaries, that represents a list of movies
 
-2. The next three tests are about a `get_friends_unique_watched()` function.
-
-In `party.py`, there should be a function named `get_friends_unique_watched`. This function should...
+2. Create a function named `get_friends_unique_watched`. This function should...
 
 - take one parameter: `user_data`
   - the value of `user_data` will be a dictionary with a `"watched"` list of movie dictionaries, and a `"friends"`
@@ -322,9 +306,7 @@ In `party.py`, there should be a function named `get_friends_unique_watched`. Th
 
 ### Wave 4
 
-1. There are four tests about a `get_available_recs` function
-
-Create a function named `get_available_recs`
+1. Create a function named `get_available_recs`. This function should...
 
 - takes one parameter: `user_data`
   - `user_data` will have a field `"subscriptions"`. The value of `"subscriptions"` is a list of strings
@@ -338,9 +320,7 @@ Create a function named `get_available_recs`
 
 ### Wave 5
 
-1. There are four tests about a `get_new_rec_by_genre` function
-
-Create a function named `get_new_rec_by_genre`
+1. Create a function named  `get_new_rec_by_genre`. This function should...
 
 - takes one parameter: `user_data`
 - Consider the user's most frequently watched genre. Then, determine a list of recommended movies. A movie should be added to this list if and only if:
@@ -349,9 +329,7 @@ Create a function named `get_new_rec_by_genre`
   - The `"genre"` of the movie is the same as the user's most frequent genre
 - Return the list of recommended movies
 
-2. There are also two tests about a `get_rec_from_favorites` function
-
-Create a function named `get_rec_from_favorites`
+2. Create a function named  `get_rec_from_favorites`. This function should...
 
 - takes one parameter: `user_data`
   - `user_data` will have a field `"favorites"`. The value of `"favorites"` is a list of movie dictionaries

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Note: For Waves 2, 3, 4, and 5, your implementation of each of the functions sho
 
 1. Create a function named  `get_new_rec_by_genre`. This function should...
 
-- takes one parameter: `user_data`
+- take one parameter: `user_data`
 - Consider the user's most frequently watched genre. Then, determine a list of recommended movies. A movie should be added to this list if and only if:
   - The user has not watched it
   - At least one of the user's friends has watched

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Note: For Waves 2, 3, 4, and 5, your implementation of each of the functions sho
 
 1. Create a function named `get_available_recs`. This function should...
 
-- takes one parameter: `user_data`
+- take one parameter: `user_data`
   - `user_data` will have a field `"subscriptions"`. The value of `"subscriptions"` is a list of strings
     - This represents the names of streaming services that the user has access to
     - Each friend in `"friends"` has a watched list. Each movie in the watched list has a `"host"`, which is a string that says what streaming service it's hosted on
@@ -331,10 +331,10 @@ Note: For Waves 2, 3, 4, and 5, your implementation of each of the functions sho
 
 2. Create a function named  `get_rec_from_favorites`. This function should...
 
-- takes one parameter: `user_data`
+- take one parameter: `user_data`
   - `user_data` will have a field `"favorites"`. The value of `"favorites"` is a list of movie dictionaries
     - This represents the user's favorite movies
-- Then, determine a list of recommended movies. A movie should be added to this list if and only if:
+- Determine a list of recommended movies. A movie should be added to this list if and only if:
   - The movie is in the user's `"favorites"`
   - None of the user's friends have watched it
 - Return the list of recommended movies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-attrs==20.3.0
+attrs==21.4.0
 iniconfig==1.1.1
-packaging==20.8
-pluggy==0.13.1
-pprintpp==0.4.0
-py==1.10.0
-pyparsing==2.4.7
-pytest==6.2.1
-toml==0.10.2
+packaging==21.3
+pluggy==1.0.0
+py==1.11.0
+pyparsing==3.0.7
+pytest==7.1.1
+tomli==2.0.1

--- a/tests/test_wave_01.py
+++ b/tests/test_wave_01.py
@@ -15,8 +15,8 @@ def test_create_successful_movie():
     new_movie = create_movie(movie_title, genre, rating)
 
     # Assert
-    assert new_movie["title"] is MOVIE_TITLE_1
-    assert new_movie["genre"] is GENRE_1
+    assert new_movie["title"] == MOVIE_TITLE_1
+    assert new_movie["genre"] == GENRE_1
     assert new_movie["rating"] == pytest.approx(RATING_1)
 
 @pytest.mark.skip()
@@ -75,9 +75,9 @@ def test_adds_movie_to_user_watched():
 
     # Assert
     assert len(updated_data["watched"]) is 1
-    assert updated_data["watched"][0]["title"] is MOVIE_TITLE_1
-    assert updated_data["watched"][0]["genre"] is GENRE_1
-    assert updated_data["watched"][0]["rating"] is RATING_1
+    assert updated_data["watched"][0]["title"] == MOVIE_TITLE_1
+    assert updated_data["watched"][0]["genre"] == GENRE_1
+    assert updated_data["watched"][0]["rating"] == RATING_1
 
 @pytest.mark.skip()
 def test_adds_movie_to_user_watchlist():
@@ -96,9 +96,9 @@ def test_adds_movie_to_user_watchlist():
 
     # Assert
     assert len(updated_data["watchlist"]) is 1
-    assert updated_data["watchlist"][0]["title"] is MOVIE_TITLE_1
-    assert updated_data["watchlist"][0]["genre"] is GENRE_1
-    assert updated_data["watchlist"][0]["rating"] is RATING_1
+    assert updated_data["watchlist"][0]["title"] == MOVIE_TITLE_1
+    assert updated_data["watchlist"][0]["genre"] == GENRE_1
+    assert updated_data["watchlist"][0]["rating"] == RATING_1
 
 @pytest.mark.skip()
 def test_moves_movie_from_watchlist_to_empty_watched():

--- a/tests/test_wave_01.py
+++ b/tests/test_wave_01.py
@@ -119,6 +119,7 @@ def test_moves_movie_from_watchlist_to_empty_watched():
     assert len(updated_data["watchlist"]) is 0
     assert len(updated_data["watched"]) is 1
     
+    raise Exception("Test needs to be completed.")
     # *******************************************************************************************
     # ****** Add assertions here to test that the correct movie was added to "watched" **********
     # *******************************************************************************************
@@ -142,6 +143,7 @@ def test_moves_movie_from_watchlist_to_watched():
     assert len(updated_data["watchlist"]) is 1
     assert len(updated_data["watched"]) is 2
     
+    raise Exception("Test needs to be completed.")
     # *******************************************************************************************
     # ****** Add assertions here to test that the correct movie was added to "watched" **********
     # *******************************************************************************************

--- a/tests/test_wave_03.py
+++ b/tests/test_wave_03.py
@@ -55,6 +55,7 @@ def test_friends_unique_movies_not_duplicated():
     # Arrange
     assert len(friends_unique_movies) == 3
 
+    raise Exception("Test needs to be completed.")
     # *************************************************************************************************
     # ****** Add assertions here to test that the correct movies are in friends_unique_movies **********
     # **************************************************************************************************

--- a/tests/test_wave_05.py
+++ b/tests/test_wave_05.py
@@ -53,6 +53,7 @@ def test_new_genre_rec_from_empty_friends():
         ]
     }
 
+    raise Exception("Test needs to be completed.")
     # *********************************************************************
     # ****** Complete the Act and Assert Portions of theis tests **********
     # *********************************************************************

--- a/tests/test_wave_05.py
+++ b/tests/test_wave_05.py
@@ -76,6 +76,7 @@ def test_unique_from_empty_favorites():
     # Arrange
     sonyas_data = {
         "watched": [],
+        "favorites": [],
         "friends": [
             {
                 "watched": [INTRIGUE_1b]
@@ -87,7 +88,7 @@ def test_unique_from_empty_favorites():
     }
 
     # Act
-    recommendations = get_new_rec_by_genre(sonyas_data)
+    recommendations = get_rec_from_favorites(sonyas_data)
 
     # Assert
     assert len(recommendations) == 0
@@ -97,18 +98,13 @@ def test_new_rec_from_empty_friends():
     # Arrange
     sonyas_data = {
         "watched": [INTRIGUE_1b],
-        "friends": [
-            {
-                "watched": []
-            },
-            {
-                "watched": []
-            }
-        ]
+        "favorites": [INTRIGUE_1b],
+        "friends": []
     }
 
     # Act
-    recommendations = get_new_rec_by_genre(sonyas_data)
+    recommendations = get_rec_from_favorites(sonyas_data)
 
     # Assert
-    assert len(recommendations) == 0
+    assert len(recommendations) == 1
+    assert INTRIGUE_1b in recommendations


### PR DESCRIPTION
Changes in this PR
- correction: `is` changed to `==` in Wave 01 tests
- correction: last two tests in Wave 05 call correct function
- Exception raised for incomplete tests
- README updated to not spell out the number of tests per wave

Still to look at:
- Bringing in the edge case tests that were added for C16 and accidentally dropped for C17