### PR TITLE
Update test edge cases

### DIFF
--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -78,6 +78,17 @@ USER_DATA_2 = {
         ],    
 }
 
+USER_DATA_2b = {
+    "watched": [
+        INTRIGUE_1,
+        FANTASY_2,
+        ACTION_1,
+        FANTASY_1,
+        FANTASY_3,
+        INTRIGUE_2,
+    ]
+}
+
 #-----WAVE 3--------
 USER_DATA_3 = copy.deepcopy(USER_DATA_2)
 USER_DATA_3["friends"] =  [
@@ -146,6 +157,7 @@ USER_DATA_4 = {
         {
             "watched": [
                 FANTASY_1b,
+                FANTASY_4b,
                 ACTION_1b,
                 INTRIGUE_1b,
                 INTRIGUE_3b,
@@ -172,6 +184,9 @@ USER_DATA_5["favorites"] = [
 
 def clean_wave_2_data():
     return copy.deepcopy(USER_DATA_2)
+
+def clean_wave_2b_data():
+    return copy.deepcopy(USER_DATA_2b)
 
 def clean_wave_3_data():
     return copy.deepcopy(USER_DATA_3)

--- a/tests/test_wave_01.py
+++ b/tests/test_wave_01.py
@@ -80,6 +80,26 @@ def test_adds_movie_to_user_watched():
     assert updated_data["watched"][0]["rating"] == RATING_1
 
 @pytest.mark.skip()
+def test_adds_movie_to_non_empty_user_watched():
+    # Arrange
+    movie = {
+        "title": MOVIE_TITLE_1,
+        "genre": GENRE_1,
+        "rating": RATING_1
+    }
+    user_data = {
+        "watched": [FANTASY_2]
+    }
+
+    # Act
+    updated_data = add_to_watched(user_data, movie)
+
+    # Assert
+    assert len(updated_data["watched"]) == 2
+    assert movie in updated_data["watched"]
+    assert FANTASY_2 in updated_data["watched"]
+
+@pytest.mark.skip()
 def test_adds_movie_to_user_watchlist():
     # Arrange
     movie = {
@@ -99,6 +119,26 @@ def test_adds_movie_to_user_watchlist():
     assert updated_data["watchlist"][0]["title"] == MOVIE_TITLE_1
     assert updated_data["watchlist"][0]["genre"] == GENRE_1
     assert updated_data["watchlist"][0]["rating"] == RATING_1
+
+@pytest.mark.skip()
+def test_adds_movie_to_non_empty_user_watchlist():
+    # Arrange
+    movie = {
+        "title": MOVIE_TITLE_1,
+        "genre": GENRE_1,
+        "rating": RATING_1
+    }
+    user_data = {
+        "watched": [FANTASY_2]
+    }
+
+    # Act
+    updated_data = add_to_watchlist(user_data, movie)
+
+    # Assert
+    assert len(updated_data["watchlist"]) == 2
+    assert movie in updated_data["watchlist"]
+    assert FANTASY_2 in updated_data["watchlist"]
 
 @pytest.mark.skip()
 def test_moves_movie_from_watchlist_to_empty_watched():

--- a/tests/test_wave_02.py
+++ b/tests/test_wave_02.py
@@ -40,6 +40,18 @@ def test_most_watched_genre():
     assert janes_data == clean_wave_2_data()
 
 @pytest.mark.skip()
+def test_most_watched_genre_order_mixed():
+    # Arrange
+    janes_data = clean_wave_2b_data()
+
+    # Act
+    popular_genre = get_most_watched_genre(janes_data)
+
+    # Assert
+    assert popular_genre == "Fantasy"
+    assert janes_data == clean_wave_2b_data()
+
+@pytest.mark.skip()
 def test_genre_is_None_if_empty_watched():
     # Arrange
     janes_data = {


### PR DESCRIPTION
This change adds more testing and updates testing constants to catch edge cases in student code. Addresses this Asana ticket: https://app.asana.com/0/0/1203033913327223/f. The following scenarios are addressed:

1. In `add_to_watched` and `add_to_watchlist`, ensure that if the corresponding list is not empty, that adding a movie does not replace the existing list.
2. In `get_most_watched_genre`, included a test case where the ordering of the movies is switched up. Students were just returning the first movie in the list. Wanted to avoid code as well that just returns the last element.
3. In Waves 4 and 5, one of the test constants has been updated so that the two friends share a movie in common that will need to be returned in recommendations. This will ensure students are properly filtering out duplicates.