### PR TITLE
Update pytest version to 7.4.2, remove unnecessary dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,4 @@
-attrs==21.4.0
-iniconfig==1.1.1
-packaging==21.3
-pluggy==1.0.0
-py==1.11.0
-pyparsing==3.0.7
-pytest==7.1.1
-tomli==2.0.1
+iniconfig==2.0.0
+packaging==23.1
+pluggy==1.3.0
+pytest==7.4.2


### PR DESCRIPTION
Updating from pytest 7.1.1 to 7.4.2 for the scaffold branch. I created a solution branch based on the code from the existing solution branch and pushed it up for testing so we can see everything pass: https://github.com/AdaGold/viewing-party/tree/kelsey_solution_updated_pytest

When we've merged in the updates, I plan to remove the new and prior solution branches from this repo in favor of the AdaAnswers repo https://github.com/AdaAnswers/viewing-party.